### PR TITLE
Removed Clans from main_menu.json

### DIFF
--- a/projects/TrG Ender Eye UI/BP/entities/main_menu.json
+++ b/projects/TrG Ender Eye UI/BP/entities/main_menu.json
@@ -29,10 +29,6 @@
             "action": "open_bank_menu"
           },
           {
-            "button_text": "Clans",
-            "action": "open_clans_menu"
-          },
-          {
             "button_text": "Daily Rewards",
             "action": "tp_daily_rewards"
           },


### PR DESCRIPTION
Removed the clans feature from the main_menu.json as it was in the files for some reason. Can be re-added whenever.