### PR TITLE
Fixed settings_menu.mcfunction option buttons

### DIFF
--- a/projects/TrG Ender Eye UI/BP/functions/settings_menu.mcfunction
+++ b/projects/TrG Ender Eye UI/BP/functions/settings_menu.mcfunction
@@ -1,13 +1,11 @@
 # Settings Menu Functions
-notifications
-# Currently does nothing
+# notifications
 tellraw @p {"text":"Notifications feature is not available yet.", "color":"yellow"}
 
-unknown
-# Currently does nothing
+# unknown
 tellraw @p {"text":"This feature is not available yet.", "color":"yellow"}
 
-night_vision
+# night_vision
 # Grants night vision for 250 hours (900,000 seconds)
 effect @p night_vision 900000 1 true
 tellraw @p {"text":"You have received Night Vision!", "color":"blue"}


### PR DESCRIPTION
Fixed the option menu icon buttons for the settings menu to have a # before and removed excess information.